### PR TITLE
Add mui-theme file with basic styles.

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -3,18 +3,22 @@ import SimpleAppBar from "./AppBar";
 import SchoolTable from "./SchoolTable";
 import Grid from "@material-ui/core/Grid";
 import Footer from "./Footer";
+import MuiThemeProvider from '@material-ui/core/styles/MuiThemeProvider';
+import muiTheme from '../theme/muiTheme';
 
 const App = () => (
-  <div>
-    <SimpleAppBar />
-    <Grid container>
-      <Grid item xs={12}>
-        <SchoolTable />
+  <MuiThemeProvider theme={muiTheme}>
+    <div>
+      <SimpleAppBar />
+      <Grid container>
+        <Grid item xs={12}>
+          <SchoolTable />
+        </Grid>
+        <Grid item xs={3} />
       </Grid>
-      <Grid item xs={3} />
-    </Grid>
-    <Footer />
-  </div>
+      <Footer />
+    </div>
+  </MuiThemeProvider>
 );
 
 export default App;

--- a/src/theme/muiTheme.js
+++ b/src/theme/muiTheme.js
@@ -1,0 +1,36 @@
+import { createMuiTheme } from '@material-ui/core/styles';
+
+const theme = createMuiTheme({
+  typography: {
+    useNextVariants: true,
+  },
+  palette: {
+    primary: {
+      light: '#58943a',
+      main: '#28660a',
+      dark: '#003a00',
+      contrastText: '#fff',
+    },
+    secondary: {
+      light: '#eab842',
+      main: '#b48803',
+      dark: '#805b00',
+      contrastText: '#000',
+    },
+    background: {
+      paper: '#f5f5f5',
+    }
+  },
+  overrides: {
+    MUIDataTableBodyCell: {
+      root: {
+        background: '#fff',
+        color: '#000',
+        height: 30,
+        fontSize: 15,
+      },
+    },
+  },
+});
+
+export default theme;


### PR DESCRIPTION
This appears to be the correct way to override some of the core MUI styles.

It includes colours as per: https://material.io/tools/color/#!/?view.left=0&view.right=1&primary.color=b48803&secondary.color=F44336

Screenshot of desktop view:

![styles-adjusted](https://user-images.githubusercontent.com/491346/54430662-ebb2af80-472c-11e9-9214-688c5c70a478.png)
